### PR TITLE
Set default buffer size for WISH

### DIFF
--- a/client/player/dashjs4/index.html
+++ b/client/player/dashjs4/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script type="text/javascript" src="https://cdn.dashjs.org/v4.0.0/dash.all.min.js"></script>
+    <script type="text/javascript" src="https://cdn.dashjs.org/v4.4.0/dash.all.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <!--    <script type="text/javascript" src="https://cdn.bitmovin.com/analytics/web/2/bitmovinanalytics.min.js"></script>-->
     <!--    <script type="text/javascript" src="https://cdn.dashjs.org/latest/dash.all.min.js"></script>-->

--- a/client/player/wishlog/index.html
+++ b/client/player/wishlog/index.html
@@ -43,9 +43,7 @@
         abr: {
           useDefaultABRRules: false,
           movingAverageMethod: 'ewma'
-        },
-        stableBufferTime: 20,
-        bufferTimeAtTopQuality: 20
+        }
       }
     })
 

--- a/client/player/wishlog/wish.js
+++ b/client/player/wishlog/wish.js
@@ -120,7 +120,8 @@ function WISHRuleClass() {
       qualityLevelList = getQualityFunctionLogarit(bitrates);
       const m_xi = 0.8;
       const m_delta = 1;
-      buffer_size = mediaPlayerModel.getStableBufferTime();
+      // buffer_size = mediaPlayerModel.getStableBufferTime();
+      console.log("------------------- buffer_size: " + buffer_size);
       setWeightsLogarit(m_xi, m_delta, qualityLevelList, SD);
 
       if (currentbufferS <= low_buff_thresS) {

--- a/client/player/wishmmsp/index.html
+++ b/client/player/wishmmsp/index.html
@@ -43,9 +43,7 @@
         abr: {
           useDefaultABRRules: false,
           movingAverageMethod: 'ewma'
-        },
-        stableBufferTime: 20,
-        bufferTimeAtTopQuality: 20
+        }
       }
     })
 

--- a/client/player/wishmmsp/wish.js
+++ b/client/player/wishmmsp/wish.js
@@ -120,7 +120,8 @@ function WISHRuleClass() {
             const m_xi = 0.8;
             const m_delta = 1;
             buffer_size = mediaPlayerModel.getStableBufferTime();
-            console.log("------------------- currentbufferS: " + currentbufferS);
+            // buffer_size = 30; // = bufferTimeAtTopQuality
+            console.log("------------------- buffer_size: " + buffer_size);
             setWeights(m_xi, m_delta, qualityLevelList, SD);
 
             if (currentbufferS <= low_buff_thresS) {
@@ -156,7 +157,7 @@ function WISHRuleClass() {
 
             // If the bitrate is not changed
             if (next_selected_quality === last_selected_quality) {
-                console.log("\t\t Quality in NOT changed: " + next_selected_quality);
+                console.log("\t\t Quality is NOT changed: " + next_selected_quality);
                 return switchRequest;
             }
             else {


### PR DESCRIPTION
For a fair comparison, set the buffer size as default in dash.js for WISH

This changeset is based on https://github.com/cd-athena/WISH-CAdViSE/pull/2
